### PR TITLE
Fix: Correct pnpm setup in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,12 @@ jobs:
           node-version: 18
           cache: 'pnpm'
 
-      - name: Enable pnpm
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install
       - uses: pnpm/action-setup@v2
         with:
           version: 8
-          run_install: true
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Run tests
         run: pnpm -r test


### PR DESCRIPTION
The previous CI configuration had a redundant and incorrectly ordered pnpm setup, causing errors.

This commit fixes the following issues:
- Removes the `corepack enable` step, as `pnpm/action-setup` handles pnpm installation.
- Moves the `pnpm/action-setup@v2` action to before the `pnpm install` step to ensure pnpm is available.
- Removes `run_install: true` from `pnpm/action-setup@v2` to avoid conflicts with the separate install step.

These changes ensure that pnpm is correctly installed and configured in the CI environment.